### PR TITLE
Fix issue 11

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -2,4 +2,16 @@
 
 echo ${INTER_RUN_INTERVAL}
 
+#add hosts to /etc/hosts to prevent HostNotFoundErrors
+if [[ ! -z "${HOSTS}" ]]; then
+  oIFS=${IFS}
+  IFS=";"
+  declare -a newhosts=($HOSTS)
+  IFS="$oIFS"
+  unset oIFS
+  for i in "${newhosts[@]}"; do
+    echo "$i" >> /etc/hosts
+  done
+fi
+
 while poetry run /app/main.py; do sleep ${INTER_RUN_INTERVAL}; done

--- a/src/main.py
+++ b/src/main.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     sender = os.environ.get("MAIL_SENDER")
     destination = os.environ.get("MAIL_DESTINATION")
     printfailedmessage = (os.getenv('PRINT_FAILED_MSG', 'False') == 'True')
-    pdfkit_options = os.environ.get("WKHTMLTOPDF_OPTIONS","{}")
+    pdfkit_options = os.environ.get("WKHTMLTOPDF_OPTIONS")
     print("Running emails-html-to-pdf")
 
     process_mail(imap_url=server_imap,


### PR DESCRIPTION
This PR fixes #11 

This PR introduces 2 new Environment Variables:

### HOSTS
This var is a semicolon separated list of hosts that should be added to `/etc/hosts` to prevent dns lookup failures.
e.x.:
`HOSTS=127.0.0.1 tracking.paypal.com;127.0.0.1 my.custom.host.tld`

### WKHTMLTOPDF_OPTIONS
This var is a python dict (json) representation of `wkhtmltopdf_options` that can be passed to the used pdfkit library.

e.x.:
`WKHTMLTOPDF_OPTIONS='{"load-media-error-handling":"ignore"}'`

More options for wkhtmltopdf can be found [here](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt). 
More about the usage of those options with pdfkit can be found [here](https://github.com/JazzCore/python-pdfkit#usage)

### Examples
I had the problem that the tracking pixel of PayPal caused a HostNotFoundError. This was because the container was not able to resolve the `tracking.paypal.com` domain.

With this PR, I would add following to the docker-compose.yml:
```

...
    environment:
        ...
        HOSTS=127.0.0.1 tracking.paypal.com
        WKHTMLTOPDF_OPTIONS={"load-media-error-handling":"ignore"}
```