### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.9
+FROM python:3.9-slim
 
-RUN apt-get update
-RUN apt-get install -y wkhtmltopdf
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install wget
+RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb
+RUN apt-get install -y ./wkhtmltox_0.12.6-1.buster_amd64.deb
+RUN rm -rf /var/lib/apt/lists/* && rm wkhtmltox_0.12.6-1.buster_amd64.deb
 
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 RUN pip3 install poetry


### PR DESCRIPTION
Hi,

i've tried several ways to implement this project into a small alpine container.

https://github.com/Surnet/docker-wkhtmltopdf provides a very good base image with python support.
Nevertheless, i ran into trouble when installing the pip dependencies. I've read some documentation and guides and found this one:
https://pythonspeed.com/articles/alpine-docker-python/
seems like using alpine would not significantly decrease the image size.

Since the primary target of #17 was to decrease the total image size, i tried to change from `python:3.9` to `python:3.9-slim`.

Et voila: The image size was reduced from 1.5GB to 330MB!

In my eyes, this PR will solve the idea behind #17 though it does not use alpine exactly.

**A positive side effect**
I switched from upstream wkhtmltopdf to static precompiled one which includes qt-patches that are neccessary for some options that can be added since #12.