### PR TITLE
Improved support for search criteria

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
 
-RUN apt-get update && apt-get -y install wget
+RUN apt-get update && apt-get -y install wget git
 RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb
 RUN apt-get install -y ./wkhtmltox_0.12.6-1.buster_amd64.deb
 RUN rm -rf /var/lib/apt/lists/* && rm wkhtmltox_0.12.6-1.buster_amd64.deb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "python.formatting.blackArgs": [
         "--line-length",
         "88"
-    ]
+    ],
+    "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ The following parameters are used (defaults in parentheses):
 * `HOSTS`: [Semicolon separated list of hosts](https://github.com/rob-luke/emails-html-to-pdf/pull/12) that should be added to /etc/hosts to prevent dns lookup failures 
 * `WKHTMLTOPDF_OPTIONS`: Python dict (json) representation of wkhtmltopdf_options that can be passed to the used pdfkit library
 * `MAIL_MESSAGE_FLAG`: Flag to apply to email after processing.  
-    Must be one of [imap-tools flags](https://github.com/ikvk/imap_tools/blob/7f8fd5e4f3976bbd2efa507843c577affa61d996/imap_tools/consts.py#L10). Values: SEEN (default), ANSWERED, FLAGGED, DELETED, DRAFT, RECENT
+    Must be one of [imap-tools flags](https://github.com/ikvk/imap_tools/blob/7f8fd5e4f3976bbd2efa507843c577affa61d996/imap_tools/consts.py#L10). Values: SEEN (default), ANSWERED, FLAGGED, DELETED
+* `IMAP_FILTER`: Criteria to use when searching for mail to be processed.
+    If no value is provided, a suitable value is determined based on the `MAIL_MESSAGE_FLAG`.
+    See [imap-tools search criteria documentation](https://pypi.org/project/imap-tools/#search-criteria) for how to specify the filter.
+    This should be in the text format (e.g. `(TEXT "hello" NEW)` rather than `AND(text="hello", new=True)`)
 
 ### Docker-Compose
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following parameters are used (defaults in parentheses):
 * `HOSTS`: [Semicolon separated list of hosts](https://github.com/rob-luke/emails-html-to-pdf/pull/12) that should be added to /etc/hosts to prevent dns lookup failures 
 * `WKHTMLTOPDF_OPTIONS`: Python dict (json) representation of wkhtmltopdf_options that can be passed to the used pdfkit library
 * `MAIL_MESSAGE_FLAG`: Flag to apply to email after processing.  
-    Must be one of [imap-tools flags](https://github.com/ikvk/imap_tools/blob/7f8fd5e4f3976bbd2efa507843c577affa61d996/imap_tools/consts.py#L10). Values: SEEN (default), ANSWERED, FLAGGED, DELETED
+    Must be one of: SEEN (default), ANSWERED, FLAGGED, UNFLAGGED, DELETED
 * `IMAP_FILTER`: Criteria to use when searching for mail to be processed.
     If no value is provided, a suitable value is determined based on the `MAIL_MESSAGE_FLAG`.
     See [imap-tools search criteria documentation](https://pypi.org/project/imap-tools/#search-criteria) for how to specify the filter.

--- a/src/main.py
+++ b/src/main.py
@@ -82,6 +82,7 @@ def process_mail(
     printfailedmessage=None,
     pdfkit_options=None,
     mail_msg_flag=None,
+    filter_criteria=AND(seen=False),
 ):
     print("Starting mail processing run", flush=True)
     if printfailedmessage:
@@ -99,7 +100,7 @@ def process_mail(
     with MailBox(imap_url).login(imap_username, imap_password, imap_folder) as mailbox:
         for i, msg in enumerate(
             mailbox.fetch(
-                criteria=AND(seen=False),
+                criteria=filter_criteria,
                 limit=num_emails_limit,
                 mark_seen=False,
             )
@@ -166,25 +167,55 @@ def process_mail(
                     use_tls=smtp_tls,
                 )
 
-                if mark_msg:
-                    flag = None
-                    if mail_msg_flag == "SEEN":
-                        flag = MailMessageFlags.SEEN
-                    elif mail_msg_flag == "ANSWERED":
-                        flag = MailMessageFlags.ANSWERED
-                    elif mail_msg_flag == "FLAGGED":
-                        flag = MailMessageFlags.FLAGGED
-                    elif mail_msg_flag == "DELETED":
-                        flag = MailMessageFlags.DELETED
-                    elif mail_msg_flag == "DRAFT":
-                        flag = MailMessageFlags.DRAFT
-                    elif mail_msg_flag == "RECENT":
-                        flag = MailMessageFlags.RECENT
-                    else:
-                        flag = MailMessageFlags.SEEN
-                    mailbox.flag(msg.uid, flag, True)
+                if mark_msg and mail_msg_flag in MailMessageFlags.all:
+                    mailbox.flag(msg.uid, mail_msg_flag, True)
                 os.remove(filename)
     print("Completed mail processing run\n\n", flush=True)
+
+
+def _get_mail_message_flag():
+    """Determine mail message flag to set on processed emails from environment variable.
+    
+    Only valid options are "ANSWERED", "FLAGGED", "DELETED" and "SEEN". Any other values will default to "SEEN".
+
+    DRAFT flag is excluded as it can cause strange behaviour with inbound mail becoming outbound.
+    RECENT flag is excluded as it is read-only
+    """
+    mail_message_flag = os.environ.get("MAIL_MESSAGE_FLAG", 'SEEN').upper()
+    if mail_message_flag == "ANSWERED":
+        return MailMessageFlags.ANSWERED
+    elif mail_message_flag == "FLAGGED":
+        return MailMessageFlags.FLAGGED
+    elif mail_message_flag == "DELETED":
+        return MailMessageFlags.DELETED
+    else:
+        return MailMessageFlags.SEEN
+
+
+def _get_imap_filter(mail_message_flag):
+    """Determine mail message filter to apply when searching for mail from environment variable.
+
+    If no environment variable is provided, a suitable value is determined from the mail message flag.
+    If no suitable value can be determined, an error is raised.
+    """
+    raw_filter_criteria = os.environ.get("IMAP_FILTER")
+    if raw_filter_criteria:
+        return raw_filter_criteria
+
+    # No value specified so generate a default from the message flag
+    if mail_message_flag == MailMessageFlags.SEEN:
+        return AND(seen=False)
+    elif mail_message_flag == MailMessageFlags.ANSWERED:
+        return AND(answered=False)
+    elif mail_message_flag == MailMessageFlags.FLAGGED:
+        return AND(flagged=False)
+    elif mail_message_flag == MailMessageFlags.DELETED:
+        # Search for undeleted while possible doesn't make sense
+        # so just search for all
+        return AND(all=True)
+    else:
+        # Can't determine an appropriate value so make the user supply one
+        raise ValueError("Could not determine IMAP filter from mail message flag. You must specify the filter manually.")
 
 
 if __name__ == "__main__":
@@ -202,7 +233,9 @@ if __name__ == "__main__":
 
     printfailedmessage = os.getenv("PRINT_FAILED_MSG", "False") == "True"
     pdfkit_options = os.environ.get("WKHTMLTOPDF_OPTIONS")
-    mail_msg_flag = os.environ.get("MAIL_MESSAGE_FLAG")
+    mail_msg_flag = _get_mail_message_flag()
+
+    filter_criteria = _get_imap_filter(mail_msg_flag)
 
     print("Running emails-html-to-pdf")
 
@@ -219,4 +252,5 @@ if __name__ == "__main__":
         smtp_tls=smtp_tls,
         smtp_port=smtp_port,
         mail_msg_flag=mail_msg_flag,
+        filter_criteria=filter_criteria,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -167,8 +167,8 @@ def process_mail(
                     use_tls=smtp_tls,
                 )
 
-                if mark_msg and mail_msg_flag in MailMessageFlags.all:
-                    mailbox.flag(msg.uid, mail_msg_flag, True)
+                if mark_msg and mail_msg_flag and mail_msg_flag[0] in MailMessageFlags.all:
+                    mailbox.flag(msg.uid, mail_msg_flag[0], mail_msg_flag[1])
                 os.remove(filename)
     print("Completed mail processing run\n\n", flush=True)
 
@@ -176,20 +176,24 @@ def process_mail(
 def _get_mail_message_flag():
     """Determine mail message flag to set on processed emails from environment variable.
     
-    Only valid options are "ANSWERED", "FLAGGED", "DELETED" and "SEEN". Any other values will default to "SEEN".
+    Only valid options are "ANSWERED", "FLAGGED", "UNFLAGGED", "DELETED" and "SEEN". Any other values will default to "SEEN".
 
     DRAFT flag is excluded as it can cause strange behaviour with inbound mail becoming outbound.
     RECENT flag is excluded as it is read-only
+
+    Returns a tuple. The first part is the flag and the second is if it should be added (True) or removed (False).
     """
     mail_message_flag = os.environ.get("MAIL_MESSAGE_FLAG", 'SEEN').upper()
     if mail_message_flag == "ANSWERED":
-        return MailMessageFlags.ANSWERED
+        return (MailMessageFlags.ANSWERED, True)
     elif mail_message_flag == "FLAGGED":
-        return MailMessageFlags.FLAGGED
+        return (MailMessageFlags.FLAGGED, True)
+    elif mail_message_flag == "UNFLAGGED":
+        return (MailMessageFlags.FLAGGED, False)
     elif mail_message_flag == "DELETED":
-        return MailMessageFlags.DELETED
+        return (MailMessageFlags.DELETED, True)
     else:
-        return MailMessageFlags.SEEN
+        return (MailMessageFlags.SEEN, True)
 
 
 def _get_imap_filter(mail_message_flag):
@@ -203,13 +207,13 @@ def _get_imap_filter(mail_message_flag):
         return raw_filter_criteria
 
     # No value specified so generate a default from the message flag
-    if mail_message_flag == MailMessageFlags.SEEN:
-        return AND(seen=False)
-    elif mail_message_flag == MailMessageFlags.ANSWERED:
-        return AND(answered=False)
-    elif mail_message_flag == MailMessageFlags.FLAGGED:
-        return AND(flagged=False)
-    elif mail_message_flag == MailMessageFlags.DELETED:
+    if mail_message_flag[0] == MailMessageFlags.SEEN:
+        return AND(seen=(not mail_message_flag[1]))
+    elif mail_message_flag[0] == MailMessageFlags.ANSWERED:
+        return AND(answered=(not mail_message_flag[1]))
+    elif mail_message_flag[0] == MailMessageFlags.FLAGGED:
+        return AND(flagged=(not mail_message_flag[1]))
+    elif mail_message_flag[0] == MailMessageFlags.DELETED and mail_message_flag[1]:
         # Search for undeleted while possible doesn't make sense
         # so just search for all
         return AND(all=True)

--- a/src/main.py
+++ b/src/main.py
@@ -167,7 +167,11 @@ def process_mail(
                     use_tls=smtp_tls,
                 )
 
-                if mark_msg and mail_msg_flag and mail_msg_flag[0] in MailMessageFlags.all:
+                if (
+                    mark_msg
+                    and mail_msg_flag
+                    and mail_msg_flag[0] in MailMessageFlags.all
+                ):
                     mailbox.flag(msg.uid, mail_msg_flag[0], mail_msg_flag[1])
                 os.remove(filename)
     print("Completed mail processing run\n\n", flush=True)
@@ -175,7 +179,7 @@ def process_mail(
 
 def _get_mail_message_flag():
     """Determine mail message flag to set on processed emails from environment variable.
-    
+
     Only valid options are "ANSWERED", "FLAGGED", "UNFLAGGED", "DELETED" and "SEEN". Any other values will default to "SEEN".
 
     DRAFT flag is excluded as it can cause strange behaviour with inbound mail becoming outbound.
@@ -183,7 +187,7 @@ def _get_mail_message_flag():
 
     Returns a tuple. The first part is the flag and the second is if it should be added (True) or removed (False).
     """
-    mail_message_flag = os.environ.get("MAIL_MESSAGE_FLAG", 'SEEN').upper()
+    mail_message_flag = os.environ.get("MAIL_MESSAGE_FLAG", "SEEN").upper()
     if mail_message_flag == "ANSWERED":
         return (MailMessageFlags.ANSWERED, True)
     elif mail_message_flag == "FLAGGED":
@@ -219,7 +223,9 @@ def _get_imap_filter(mail_message_flag):
         return AND(all=True)
     else:
         # Can't determine an appropriate value so make the user supply one
-        raise ValueError("Could not determine IMAP filter from mail message flag. You must specify the filter manually.")
+        raise ValueError(
+            "Could not determine IMAP filter from mail message flag. You must specify the filter manually."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Adds an option to specify a custom search criteria
- Fixes mail being processed multiple times if flag is not "SEEN"
  - Search was always looking for "unseen" mail. If the mail flag was not set to seen, the mail would remain unread and be processed next run. A suitable filter should now be determined, or an error raised if the user must specify one.
- Remove "DRAFT" flag option
  - Causes strange behaviour where inbound mail can be converted to an outbound draft. This can then be accidentally discarded deleting the original message or converting it back can result in the metadata of the email being lost.
- Add "UNFLAGGED" mail flag option
  - Removes the "FLAGGED" option from the message once processed