### PR TITLE
Add support for SMTP port 465

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -59,9 +59,12 @@ def send_mail(
         )
         msg.attach(part)
 
-    smtp = smtplib.SMTP(server, port)
-    if use_tls:
-        smtp.starttls()
+    if smtp_port == 465:
+        smtp = smtplib.SMTP_SSL(server, port)
+    else:
+        smtp = smtplib.SMTP(server, port)
+        if use_tls:
+            smtp.starttls()
     smtp.login(username, password)
     smtp.sendmail(send_from, send_to, msg.as_string())
     smtp.quit()

--- a/src/main.py
+++ b/src/main.py
@@ -59,7 +59,7 @@ def send_mail(
         )
         msg.attach(part)
 
-    if smtp_port == 465:
+    if port == 465:
         smtp = smtplib.SMTP_SSL(server, port)
     else:
         smtp = smtplib.SMTP(server, port)


### PR DESCRIPTION
Add support for Port 465, which requires the use of SMTP_SSL instead of SMTP and STARTTLS.