### PR TITLE
Add Header information to PDF

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -134,10 +134,10 @@ def process_mail(
                         pdftext = '<font size="-1">Reply-to: ' + join(msg.reply_to) + "</font><br />" + pdftext
                     if msg.from_values.name and msg.from_values.email:
                         pdftext = '<font size="-1"><b>' + msg.from_values.name + " </b>&lt;" + msg.from_values.email + "&gt;</font><br />" + pdftext
-                    else if msg.from_values.email:
+                    elif msg.from_values.email:
                         pdftext = '<font size="-1"><b>' + msg.from_values.email + "</b></font><br />" + pdftext
                     if msg.date_str:
-                        pdftext = msg.date_str + "<br /> + pdftext
+                        pdftext = msg.date_str + "<br />" + pdftext
                     if msg.subject:
                         pdftext = '<font size="+1"><b>' + msg.subject + "</b></font><hr>" + pdftext
                     else:

--- a/src/main.py
+++ b/src/main.py
@@ -129,9 +129,9 @@ def process_mail(
                 if show_header:
                     pdftext = "<br />" + pdftext
                     if msg.to:
-                        pdftext = '<font size="-1">To: ' + join(msg.to) + "</font><br />" + pdftext
+                        pdftext = '<font size="-1">To: ' + "".join(msg.to) + "</font><br />" + pdftext
                     if msg.reply_to:
-                        pdftext = '<font size="-1">Reply-to: ' + join(msg.reply_to) + "</font><br />" + pdftext
+                        pdftext = '<font size="-1">Reply-to: ' + "".join(msg.reply_to) + "</font><br />" + pdftext
                     if msg.from_values.name and msg.from_values.email:
                         pdftext = '<font size="-1"><b>' + msg.from_values.name + " </b>&lt;" + msg.from_values.email + "&gt;</font><br />" + pdftext
                     elif msg.from_values.email:
@@ -144,7 +144,7 @@ def process_mail(
                         pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
                 
                 if show_header_ext:
-                    pdftext = "" + join(msg.headers) + "<br /><br />"
+                    pdftext = "" + "".join(msg.headers) + "<br /><br />"
                     
                 try:
                     pdfkit.from_string(pdftext, filename, options=options)

--- a/src/main.py
+++ b/src/main.py
@@ -145,7 +145,7 @@ def process_mail(
                 
                 if show_header_ext:
                     string_data = json.dumps(msg.headers)
-                    string_data = string_data.replace('\r\n', '<br />')
+                    string_data = string_data.replace("\\r\\n", '<br />')
                     pdftext = "" + string_data + "<br /><br />" + pdftext
                     
                 try:

--- a/src/main.py
+++ b/src/main.py
@@ -136,12 +136,10 @@ def process_mail(
                         pdftext = '<font size="-1"><b>' + msg.from_values['name'] + " </b>&lt;" + msg.from_values['email'] + "&gt;</font><br />" + pdftext
                     elif msg.from_values['email']:
                         pdftext = '<font size="-1"><b>' + msg.from_values['email'] + "</b></font><br />" + pdftext
-                    if msg.date_str:
-                        pdftext = '<font size="-1">' + msg.date_str + "</font><br /><br />" + pdftext
                     if msg.subject:
-                        pdftext = '<font size="+1"><b>' + msg.subject + "</b></font><hr>" + pdftext
+                        pdftext = '<table width="100%" cellpadding="0" cellspacing="0" border="0""><tbody><tr><td><font size="+1"><b>' + msg.subject + '</b></font></td><td align="right"><font size="-1">' + msg.date_str + '</font></td></tr></table><hr>' + pdftext
                     else:
-                        pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
+                        pdftext = '<table width="100%" cellpadding="0" cellspacing="0" border="0""><tbody><tr><td><font size="+1"><b>(no subject)</b></font></td><td align="right"><font size="-1">' + msg.date_str + '</font></td></tr></table><hr>' + pdftext
                 
                 if show_header_ext:
                     string_data = json.dumps(msg.headers)

--- a/src/main.py
+++ b/src/main.py
@@ -144,9 +144,9 @@ def process_mail(
                         pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
                 
                 if show_header_ext:
-                    stringData = JSON.stringify(msg.headers);
-                    stringData = stringData.replace(new RegExp('\r?\n','g'), '<br />');
-                    pdftext = "" + stringData + "<br /><br />" + pdftext
+                    string_data = json.dump(msg.headers)
+                    string_data = string_data.replace('\r\n', '<br />')
+                    pdftext = "" + string_data + "<br /><br />" + pdftext
                     
                 try:
                     pdfkit.from_string(pdftext, filename, options=options)

--- a/src/main.py
+++ b/src/main.py
@@ -144,7 +144,7 @@ def process_mail(
                         pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
                 
                 if show_header_ext:
-                    pdftext = "" + "".join(msg.headers) + "<br /><br />"
+                    pdftext = "" + "".join(msg.headers) + "<br /><br />" + pdftext
                     
                 try:
                     pdfkit.from_string(pdftext, filename, options=options)

--- a/src/main.py
+++ b/src/main.py
@@ -132,10 +132,10 @@ def process_mail(
                         pdftext = '<font size="-1">To: ' + "".join(msg.to) + "</font><br />" + pdftext
                     if msg.reply_to:
                         pdftext = '<font size="-1">Reply-to: ' + "".join(msg.reply_to) + "</font><br />" + pdftext
-                    if msg.from_values.name and msg.from_values.email:
-                        pdftext = '<font size="-1"><b>' + msg.from_values.name + " </b>&lt;" + msg.from_values.email + "&gt;</font><br />" + pdftext
-                    elif msg.from_values.email:
-                        pdftext = '<font size="-1"><b>' + msg.from_values.email + "</b></font><br />" + pdftext
+                    if msg.from_values['name'] and msg.from_values['email']:
+                        pdftext = '<font size="-1"><b>' + msg.from_values['name'] + " </b>&lt;" + msg.from_values['email'] + "&gt;</font><br />" + pdftext
+                    elif msg.from_values['email']:
+                        pdftext = '<font size="-1"><b>' + msg.from_values['email'] + "</b></font><br />" + pdftext
                     if msg.date_str:
                         pdftext = msg.date_str + "<br />" + pdftext
                     if msg.subject:

--- a/src/main.py
+++ b/src/main.py
@@ -137,14 +137,16 @@ def process_mail(
                     elif msg.from_values['email']:
                         pdftext = '<font size="-1"><b>' + msg.from_values['email'] + "</b></font><br />" + pdftext
                     if msg.date_str:
-                        pdftext = msg.date_str + "<br />" + pdftext
+                        pdftext = '<font size="+1">' + msg.date_str + "</font><br /><br />" + pdftext
                     if msg.subject:
                         pdftext = '<font size="+1"><b>' + msg.subject + "</b></font><hr>" + pdftext
                     else:
                         pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
                 
                 if show_header_ext:
-                    pdftext = "" + "".join(msg.headers) + "<br /><br />" + pdftext
+                    stringData = JSON.stringify(msg.headers);
+                    stringData = stringData.replace(new RegExp('\r?\n','g'), '<br />');
+                    pdftext = "" + stringData + "<br /><br />" + pdftext
                     
                 try:
                     pdfkit.from_string(pdftext, filename, options=options)

--- a/src/main.py
+++ b/src/main.py
@@ -137,7 +137,7 @@ def process_mail(
                     elif msg.from_values['email']:
                         pdftext = '<font size="-1"><b>' + msg.from_values['email'] + "</b></font><br />" + pdftext
                     if msg.date_str:
-                        pdftext = '<font size="+1">' + msg.date_str + "</font><br /><br />" + pdftext
+                        pdftext = '<font size="-1">' + msg.date_str + "</font><br /><br />" + pdftext
                     if msg.subject:
                         pdftext = '<font size="+1"><b>' + msg.subject + "</b></font><hr>" + pdftext
                     else:

--- a/src/main.py
+++ b/src/main.py
@@ -144,7 +144,7 @@ def process_mail(
                         pdftext = '<font size="+1"><b>(no subject)</b></font><hr>' + pdftext
                 
                 if show_header_ext:
-                    string_data = json.dump(msg.headers)
+                    string_data = json.dumps(msg.headers)
                     string_data = string_data.replace('\r\n', '<br />')
                     pdftext = "" + string_data + "<br /><br />" + pdftext
                     


### PR DESCRIPTION
This is a pull request to add the feature requested here: #27 

The following ENV variables have been added:

EMAIL_HEADER
EMAIL_HEADER_EXT

These are both False by default.

By turning on the Header, you will now have some basic information added to the PDF such as the subject, date/time, sender and recipient. Example:

![image](https://user-images.githubusercontent.com/6588235/169666073-c9cc4aa8-0c57-485b-8f22-da1dbadf10c7.png)

Right now it displays:

- Subject
- Date
- From
- Reply-to
- To

Additional fields such as CC / BCC should probably be added.

By turning on the Header (extended) it will display the full headers as received. However, it currently does not display them very cleanly. Maybe it would be worthwhile to look into how to make them display better. It could be as simple as adding a ```<pre>``` tag.

Tested and works.